### PR TITLE
Fix issue in the spider generator

### DIFF
--- a/lib/mix/tasks/crawly.gen.spider.ex
+++ b/lib/mix/tasks/crawly.gen.spider.ex
@@ -33,11 +33,11 @@ defmodule Mix.Tasks.Crawly.Gen.Spider do
         help()
 
       true ->
-        generate_spider(opts)
+        Map.new(opts) |> generate_spider()
     end
   end
 
-  defp generate_spider(filepath: filepath, spidername: spidername) do
+  defp generate_spider(%{filepath: filepath, spidername: spidername}) do
     case File.exists?(filepath) do
       true ->
         Mix.shell().error("The spider already exists. Choose another filename")
@@ -49,11 +49,11 @@ defmodule Mix.Tasks.Crawly.Gen.Spider do
         spider_template =
           String.replace(spider_template, "SpiderTemplate", spidername)
 
-        :ok = File.write(filepath, spider_template)
-        Mix.shell().info("Done!")
+        write_file(filepath, spider_template)
     end
   end
 
+  # If filepath or spidername is missing
   defp generate_spider(_) do
     Mix.shell().error("Missing required arguments. \n")
     help()
@@ -72,6 +72,29 @@ defmodule Mix.Tasks.Crawly.Gen.Spider do
 
       errors ->
         {:error, "Unkown opions: #{inspect(errors)}"}
+    end
+  end
+
+  defp write_file(filepath, spider_template) do
+    case File.write(filepath, spider_template) do
+      :ok ->
+        Mix.shell().info("Done!")
+
+      {:error, :enoent} ->
+        Mix.shell().error(
+          "Error writing file: directory in the filepath doesn't exist"
+        )
+
+      {:error, :enotdir} ->
+        Mix.shell().error(
+          "Error writing file: directory in the filepath doesn't exist"
+        )
+
+      {:error, :enospc} ->
+        Mix.shell().error("Error writing file: no space left on the device")
+
+      {:error, :eacces} ->
+        Mix.shell().error("Error writing file: permission denied")
     end
   end
 

--- a/test/mix/tasks/gen_spider_test.exs
+++ b/test/mix/tasks/gen_spider_test.exs
@@ -1,0 +1,44 @@
+defmodule GenSpiderTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
+
+  test "when path is incorrect it sends an error message to console" do
+    captured_output =
+      capture_io(:stderr, fn ->
+        Mix.Tasks.Crawly.Gen.Spider.run([
+          "--spidername",
+          "MySpider",
+          "--filepath",
+          "./lib/spiders/my_spider.ex"
+        ])
+      end)
+
+    assert String.contains?(
+             captured_output,
+             "Error writing file: directory in the filepath doesn't exist"
+           )
+  end
+
+  describe "with valid path" do
+    test "it creates the spider in the passed directory" do
+      captured_output =
+        capture_io(fn ->
+          Mix.Tasks.Crawly.Gen.Spider.run([
+            "--spidername",
+            "MySpider",
+            "--filepath",
+            "./test/mix/tasks/my_spider.ex"
+          ])
+        end)
+
+      assert String.contains?(
+               captured_output,
+               "Done"
+             )
+
+      assert File.exists?("./test/mix/tasks/my_spider.ex")
+
+      File.rm_rf("./test/mix/tasks/my_spider.ex")
+    end
+  end
+end


### PR DESCRIPTION
It seems spider generation doesn't work in its current state. Problem is `OptParser` returns parsed arguments in the key list `[filepath: filepath, spidername: spidername]`. So, for the function `defp generate_spider(filepath: filepath, spidername: spidername)`, it's necessary to pass it in this order (filepath first etc). 

The proposed solution is to convert the key lists type into a map. 

**Changes in the PR**
1. Fixed issue with the generator
2. Handling exceptions when a file with spider can't be saved
3. Tests for spider generator 